### PR TITLE
Use events package for node 8 api

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "constants-browserify": "^1.0.0",
     "crypto-browserify": "^3.11.0",
     "domain-browser": "^1.1.7",
-    "events": "^1.1.1",
+    "events": "~2.0.0",
     "https-browserify": "0.0.1",
     "os-browserify": "^0.2.1",
     "path-browserify": "0.0.0",


### PR DESCRIPTION
Update events package to be API-compatible with the current meteor version
See: https://github.com/Gozala/events/blob/master/History.md

There's already a newer version with node 10 api compatibility, but I thought it made sense to stick to the Meteor node version.